### PR TITLE
Scale up the saliency map as done in the low-fi spectral residual det…

### DIFF
--- a/static_saliency.py
+++ b/static_saliency.py
@@ -32,6 +32,7 @@ cv2.imwrite(args["save_to"] + "/{}_lowfi_image_saliency.png".format(di), salienc
 # Initialise the more fine-grained saliency detector and compute the saliencyMap
 saliency = cv2.saliency.StaticSaliencyFineGrained_create()
 (success, saliencyMap) = saliency.computeSaliency(img)
+saliencyMap = (saliencyMap * 255).astype("uint8")
 
 # If we want a *binary* map to use for contour processing,
 # computing convex hulls, extract bounding boxes, etc... we can 


### PR DESCRIPTION
…ector, in the fine grained saliency map as well. The threshMap image without it is just a black screen.

### Changes made

For the fine-grained saliencyMap, the values had to be scaled up to [0, 255], which was missing in the source code. Just adding that on to the source so as to prevent any confusion.

